### PR TITLE
Issue 872 switch audio output

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -15,7 +15,8 @@
         encoding: '16bitInt',
         channels: 2,
         sampleRate: 8000,
-        flushingTime: 2000
+        flushingTime: 2000,
+        useAudioElement: true
    });
 
    var ws = new WebSocket(socketURL);

--- a/example/server/server.js
+++ b/example/server/server.js
@@ -29,6 +29,10 @@ function openSocket() {
         interval = setInterval(function() {
           sendData();
         }, 500);
+
+        ws.on('error', (err) => {
+          console.log(err);
+        });
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,52 @@
+{
+  "name": "pcm-player",
+  "version": "0.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "async-limiter": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.2.tgz",
+      "integrity": "sha512-zGVwKslUAD/EeqOrD1nQaBmXIHl1Vw371we8cvS8I6mYK9rmgX5tv8AAeJdfsQ3Kk5mGax2SVV/AizxdNGhl7Q==",
+      "dev": true,
+      "requires": {
+        "commander": "~2.20.3"
+      }
+    },
+    "ultron": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "dev": true
+    },
+    "ws": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+      "dev": true,
+      "requires": {
+        "async-limiter": "~1.0.0",
+        "safe-buffer": "~5.1.0",
+        "ultron": "~1.1.0"
+      }
+    }
+  }
+}

--- a/pcm-player.js
+++ b/pcm-player.js
@@ -21,7 +21,7 @@ PCMPlayer.prototype.init = function(options, onendedCallback) {
     this.typedArray = this.getTypedArray();
     this.onendedCallback = onendedCallback;
     this.feedCounter = 0;
-    this.createContext();
+    options.useAudioElement ?  this.createContextWithElement() : this.createContext();
 };
 
 // https://hackernoon.com/unlocking-web-audio-the-smarter-way-8858218c0e09
@@ -84,6 +84,25 @@ PCMPlayer.prototype.createContext = function() {
         console.error(error);
     });
 };
+
+PCMPlayer.prototype.createContextWithElement = function() {
+    this.audioCtx = new (window.AudioContext || window.webkitAudioConext)();
+    this.webAudioTouchUnlock(this.audioCtx).then(function () {
+        const destination = this.audioCtx.createMediaStreamDestination();
+        this.gainNode = this.audioCtx.createGain();
+        this.gainNode.gain.value = this.options.gain;
+        this.gainNode.connect(destination);
+        this.audioEl = new Audio();
+        this.audioEl.srcObject = destination.stream;
+        this.startTime = this.audioCtx.currentTime;
+        if (this.options.outputDeviceId) {
+            this.audioEl.setSinkId(this.options.outputDeviceId);
+        }
+        this.audioEl.play();         
+    }.bind(this), function(error) {
+        console.log(error);
+    }); 
+}
 
 PCMPlayer.prototype.isTypedArray = function(data) {
     return (data.byteLength && data.buffer && data.buffer.constructor === ArrayBuffer);


### PR DESCRIPTION
**Issue** 
https://github.com/zelloptt/zello-desktop/issues/872

**Summary**
I'm working on a feature that allows a user in `zello-desktop` to select the audio output/speaker to  play sound from. `zello-desktop` uses `pcm-player` to play messages. There are two ways to play audio: `HTMLMediaElement` and `AudioContext`. `pcm-player` uses `AudioContext`. However, you can only switch audio output using `HTMLMediaElement.setSinkId`. This PR adds the method `createContextWithElement` which creates and plays audio from an `HTMLMediaElement`. It is called when the `useAudioElement: true` flag is passed to the constructor. 

For more detail, see [this prototype](https://github.com/MarkSchu/prototype-switch-audio-input).

**Acceptance Criteria**
1. When `useAudioElement: true` in `/example/index.html` localhost:<port>/example/index.html`  plays music after a second. 
2. When `useAudioElement: false` in `/example/index.html` localhost:<port>/example/index.html`  plays music after a second. 

**QA**
1. Pull down the branch.
2. In `/example/index.html`, change `pcm-player.min.js` to `pcm-player.js` 
3. Run the socket server with `node server` from `/example/server`
4. Run a web server with `http-server -c-1` from the directory root. (If you don't have this, get with `npm i http-server -g`)
5. Hit `localhost:<port>/example/index.html` 
6. Listen for music. 
7. Repeat with `useAudioElement: false`

**Question**
I tried to minify the code, but `uglify-js` doesn't support ES6, so things like `const` break it. I assume that this is minified/built by `zello-desktop` and whatever else pulls it in. 