### PR TITLE
Add setSinkId to player

### DIFF
--- a/pcm-player.js
+++ b/pcm-player.js
@@ -137,6 +137,12 @@ PCMPlayer.prototype.setGain = function(gain) {
     this.gainNode.gain.value = gain;
 };
 
+PCMPlayer.prototype.setSinkId = function(deviceId) {
+    if (this.audioEl) {
+        this.audioEl.setSinkId(deviceId);
+    }
+}
+
 PCMPlayer.prototype.destroy = function() {
     if (this.interval) {
         clearInterval(this.interval);


### PR DESCRIPTION
**Issue** 
https://github.com/zelloptt/zello-desktop/issues/872

**Summary**
Add a `setSinkId` method so that we don't have to call setSinkId directly on `this.audioEl`. This PR outlines the full context: https://github.com/zelloptt/pcm-player/pull/5